### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   generate-changelog:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/devendew/eyecooler/security/code-scanning/2](https://github.com/devendew/eyecooler/security/code-scanning/2)

To fix the problem, add a `permissions` block to the job (or at the workflow root) specifying only the permissions required for the workflow to function. In this case, the workflow checks out code, generates a changelog, and commits/pushes the changelog to the repository. The only required permission is `contents: write`, which allows the workflow to push changes to the repository. The `permissions` block should be added under the `generate-changelog` job (line 10), before the `runs-on` key. No other permissions are needed for this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to ensure changelog updates can be committed and pushed automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->